### PR TITLE
Changes to the code that allow more freedom for the user.

### DIFF
--- a/lib/active_dynamic/attribute_definition.rb
+++ b/lib/active_dynamic/attribute_definition.rb
@@ -1,14 +1,21 @@
 module ActiveDynamic
   class AttributeDefinition
+    
+    # These attributes are mandatory.
+    attr_reader :display_name, :datatype, :value, :required, :name
 
-    attr_reader :display_name, :name, :datatype, :value
-
-    def initialize(display_name, options = {})
+    def initialize(display_name, datatype, default_value, required, options = {})
+      @name = display_name.parameterize.underscore
       @display_name = display_name
-      @name = options[:system_name] || display_name.gsub(/[^a-zA-Z\s]/, ''.freeze).gsub(/\s+/, '_'.freeze)
-      @datatype = options[:datatype]
-      @value = options[:default_value]
-      @required = options[:required]
+      @datatype = datatype
+      @value = default_value
+      @required = required
+      
+      # Optional attributes from Provider
+      options.each do |key, value|
+        self.instance_variable_set("@#{key}", value)
+        self.class.send(:attr_reader, key)
+      end 
     end
 
     def required?

--- a/lib/active_dynamic/configuration.rb
+++ b/lib/active_dynamic/configuration.rb
@@ -18,11 +18,11 @@ module ActiveDynamic
       @provider_class || NullProvider
     end
 
-    def resolve_persisted_proc
-      @resolve_persisted_proc || Proc.new { |model| false }
+    def resolve_persisted
+      @resolve_persisted || false
     end
 
-    attr_writer :provider_class, :resolve_persisted_proc
+    attr_writer :provider_class, :resolve_persisted
 
   end
 end

--- a/lib/active_dynamic/has_dynamic_attributes.rb
+++ b/lib/active_dynamic/has_dynamic_attributes.rb
@@ -12,11 +12,15 @@ module ActiveDynamic
     end
 
     def dynamic_attributes
-      if persisted?
-        ActiveDynamic.configuration.resolve_persisted_proc.call(self) ? resolve_combined : resolve_from_db
+      if persisted? && has_any?
+        ActiveDynamic.configuration.resolve_persisted ? resolve_combined : resolve_from_db
       else
         resolve_from_provider
       end
+    end
+    
+    def has_any?
+      self.active_dynamic_attributes.any?
     end
 
     def dynamic_attributes_loaded?
@@ -46,13 +50,13 @@ module ActiveDynamic
     def resolve_combined
       attributes = resolve_from_db
       resolve_from_provider.each do |attribute|
-        attributes << attribute unless attributes.find { |attr| attr.name == attribute.name }
+        attributes << ActiveDynamic::Attribute.new(attribute.as_json) unless attributes.find { |attr| attr.name == attribute.name }
       end
       attributes
     end
 
     def resolve_from_db
-      active_dynamic_attributes.order(:created_at)
+      self.active_dynamic_attributes
     end
 
     def resolve_from_provider
@@ -62,7 +66,7 @@ module ActiveDynamic
     def generate_accessors(fields)
       fields.each do |field|
 
-        add_presence_validator(field.name) if field.required?
+        #add_presence_validator(field.name) if field.required?
 
         define_singleton_method(field.name) do
           _custom_fields[field.name]
@@ -96,9 +100,7 @@ module ActiveDynamic
 
     def save_dynamic_attributes
       dynamic_attributes.each do |field|
-        props = { name: field.name, display_name: field.display_name,
-                  datatype: field.datatype, value: field.value }
-        attr = active_dynamic_attributes.find_or_initialize_by(props)
+        attr = active_dynamic_attributes.find_or_initialize_by(field.as_json)
         if _custom_fields[field.name]
           if persisted?
             attr.update(value: _custom_fields[field.name])

--- a/lib/active_dynamic/has_dynamic_attributes.rb
+++ b/lib/active_dynamic/has_dynamic_attributes.rb
@@ -12,15 +12,11 @@ module ActiveDynamic
     end
 
     def dynamic_attributes
-      if persisted? && has_any?
+      if persisted? && has_dynamic_attributes?
         ActiveDynamic.configuration.resolve_persisted ? resolve_combined : resolve_from_db
       else
         resolve_from_provider
       end
-    end
-
-    def has_any?
-      self.active_dynamic_attributes.any?
     end
 
     def dynamic_attributes_loaded?
@@ -47,6 +43,10 @@ module ActiveDynamic
 
   private
 
+    def has_dynamic_attributes?
+      active_dynamic_attributes.any?
+    end
+
     def resolve_combined
       attributes = resolve_from_db
       resolve_from_provider.each do |attribute|
@@ -56,7 +56,7 @@ module ActiveDynamic
     end
 
     def resolve_from_db
-      self.active_dynamic_attributes
+      active_dynamic_attributes
     end
 
     def resolve_from_provider

--- a/lib/active_dynamic/has_dynamic_attributes.rb
+++ b/lib/active_dynamic/has_dynamic_attributes.rb
@@ -18,7 +18,7 @@ module ActiveDynamic
         resolve_from_provider
       end
     end
-    
+
     def has_any?
       self.active_dynamic_attributes.any?
     end
@@ -66,7 +66,7 @@ module ActiveDynamic
     def generate_accessors(fields)
       fields.each do |field|
 
-        #add_presence_validator(field.name) if field.required?
+        add_presence_validator(field.name) if field.required?
 
         define_singleton_method(field.name) do
           _custom_fields[field.name]

--- a/lib/active_dynamic/initializer.rb
+++ b/lib/active_dynamic/initializer.rb
@@ -1,9 +1,15 @@
 ActiveDynamic.configure do |config|
 
-  # Specify class inyour application responsible for resolving dynamic
+  # Specify class in your application responsible for resolving dynamic
   # properties for your model. This class should accept `model` as the
   # only constructor parameter, and have a `call` method that returns
   # an array of AttributeDefinition
   config.provider_class = ActiveDynamic::NullProvider
+  
+  # When new dynamic attributes are defined after object was saved, 
+  # should object get this attributes automatically when editing? 
+  # New attribute definitions are created automatically. 
+  # Set true or false (default)
+  # config.resolve_persisted = true
 
 end

--- a/lib/active_dynamic/migration.rb
+++ b/lib/active_dynamic/migration.rb
@@ -5,10 +5,10 @@ class CreateActiveDynamicAttributesTable < ActiveRecord::Migration[4.2]
       t.integer :customizable_id, null: false
       t.string :customizable_type, limit: 50
 
-      t.string :display_name, null: false
       t.string :name
-      t.text :value
+      t.string :display_name, null: false
       t.integer :datatype
+      t.text :value
       t.boolean :required, null: false, default: false
 
       t.timestamps

--- a/test/active_dynamic_test.rb
+++ b/test/active_dynamic_test.rb
@@ -6,14 +6,14 @@ class ActiveDynamicTest < Minitest::Test
   def setup
     ActiveDynamic.configure do |config|
       config.provider_class = ProfileAttributeProvider
-      config.resolve_persisted_proc = Proc.new { |model| false }
+      config.resolve_persisted = false
     end
 
     @profile = Profile.new
   end
 
   def test_initializes_with_dynamic_attribute
-    profile = Profile.new(first_name: 'Dwight', biography: 'Beet farmer / Paper Salesman')
+    profile = Profile.new(first_name: 'Dwight', life_story: 'Beet farmer / Paper Salesman')
     profile.save!
 
     assert profile.persisted?
@@ -32,50 +32,50 @@ class ActiveDynamicTest < Minitest::Test
   end
 
   def test_sets_attribute_provider
-    puts @profile.biography
-    assert_respond_to @profile, :biography
+    puts @profile.life_story
+    assert_respond_to @profile, :life_story
   end
 
   def test_sets_display_name
-    assert_equal @profile.dynamic_attributes.map(&:display_name).first, 'life story'.freeze
+    assert_equal @profile.dynamic_attributes.map(&:display_name).first, 'Life Story'.freeze
   end
 
   def test_doesnt_reset_field_on_failed_save
-    @profile.biography = 'Beet farmer / Paper Salesman'
+    @profile.life_story = 'Beet farmer / Paper Salesman'
     @profile.save
 
     refute @profile.persisted?
-    assert_equal 'Beet farmer / Paper Salesman', @profile.biography
+    assert_equal 'Beet farmer / Paper Salesman', @profile.life_story
   end
 
   def test_persists_dynamic_attribute
     @profile.first_name = 'Dwight'
-    @profile.biography = 'Beet farmer / Paper Salesman'
+    @profile.life_story = 'Beet farmer / Paper Salesman'
     @profile.save
 
     assert @profile.persisted?
-    refute_empty @profile.biography
+    refute_empty @profile.life_story
   end
 
   def test_persists_if_initialized_with_attrs
-    profile = Profile.new(first_name: 'Michael', biography: 'Basketball machine')
+    profile = Profile.new(first_name: 'Michael', life_story: 'Basketball machine')
     profile.save
 
     assert profile.persisted?
-    refute_empty profile.biography
+    refute_empty profile.life_story
   end
 
   def test_loads_dynamic_attributes_on_find
     @profile.first_name = 'Dwight'
-    @profile.biography = 'Beet farmer / Paper Salesman'
+    @profile.life_story = 'Beet farmer / Paper Salesman'
     @profile.save
 
     loaded_profile = Profile.find(@profile.id)
-    assert_equal 'Beet farmer / Paper Salesman', loaded_profile.biography
+    assert_equal 'Beet farmer / Paper Salesman', loaded_profile.life_story
   end
 
   def test_validates_required_attribute
-    @profile.biography = nil
+    @profile.life_story = nil
     @profile.save
 
     assert !@profile.persisted?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,7 +21,6 @@ end
 
 class Profile < ActiveRecord::Base
   has_dynamic_attributes
-
   validates :first_name, presence: true
 end
 
@@ -31,13 +30,8 @@ class ProfileAttributeProvider
 
   def call
     [
-        ActiveDynamic::AttributeDefinition.new('life story',
-                                               system_name: 'biography',
-                                               required: true,
-                                               datatype: ActiveDynamic::DataType::Text),
-        ActiveDynamic::AttributeDefinition.new('age',
-                                               system_name: 'age',
-                                               datatype: ActiveDynamic::DataType::Integer)
+      ActiveDynamic::AttributeDefinition.new('Life Story', ActiveDynamic::DataType::Text, 'default value for story', true),
+      ActiveDynamic::AttributeDefinition.new('Age', ActiveDynamic::DataType::Integer, 'value for age', false),
     ]
   end
 


### PR DESCRIPTION
So,

i've changed few things, but basically it all comes to these:

- all your previous fields are now mandatory, which makes sense (display name, datatype, etc..)
- but it is possible to define custom ones which will be automatically assigned, so there is more freedom for users like me (descriptions, placeholders, other validations maybe...)
- the configuration for persisted objects is simpler now i think
- i've been hitting a wall with double inserts of dynamic attributes on create (resolve_combined) so i have added another check (has_dynamic_attributes?). This way it seems to work perfectly for any situation. For new records attributes are created like before, but when editing they are also created and available immediately. This solves now the whole problem with missing dynamic attribute definitions.

Now, there is only one more problem as far as i am concerned, and those are the required fields.
It seems like dynamic_attributes_loaded is not working as expected or I don't really understand yet what the problem is. Dynamic attributes are generated at least twice, and when they are generated the second time (for the validator) all the fields are included, not just the ones for my object.

If I do this, then it works fine (workaround in my local installation):
```ruby
if field.category == self.asset_category_id
  add_presence_validator(field.name) if field.required?
end
```
So, it seems like it is not loaded from the Provider and is not aware of the proper field set for the current object, or it could be I am doing something wrong in the controller... I am still on to that.

Anyway, I am happy I can contribute to this project.
Let me know what you think of the changes.