### PR TITLE
Reload attribute relation when resolving from database

### DIFF
--- a/lib/active_dynamic/has_dynamic_attributes.rb
+++ b/lib/active_dynamic/has_dynamic_attributes.rb
@@ -68,7 +68,7 @@ module ActiveDynamic
     end
 
     def resolve_from_db
-      active_dynamic_attributes
+      active_dynamic_attributes.reload
     end
 
     def resolve_from_provider


### PR DESCRIPTION
Noticed this when I was deleting attributes via `destroy_all` in a sidekiq job, and then calling `save` on the model. It still had the old fields. This fixes the problem. Let me know if you want to see anything else.

Also, thanks for fixing https://github.com/koss-lebedev/active_dynamic/issues/11 so fast!